### PR TITLE
generate any generator with json schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,16 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## Development Commands
+```bash
+bundle install
+
+rails s
+
+./bin/dev
+
+rails g json orders_schema.json
+
+rails db:migrate
+```

--- a/items_schema.json
+++ b/items_schema.json
@@ -4,5 +4,6 @@
     {"name": "name", "type": "string", "null": false},
     {"name": "quantity", "type": "integer", "null": false}
   ],
+  "command": "scaffold",
   "primary_field": "name"
 }

--- a/lib/generators/json_any/USAGE
+++ b/lib/generators/json_any/USAGE
@@ -1,0 +1,8 @@
+Description:
+    Explain the generator
+
+Example:
+    bin/rails generate json_any Thing
+
+    This will create:
+        what/will/it/create

--- a/lib/generators/json_any/json_any_generator.rb
+++ b/lib/generators/json_any/json_any_generator.rb
@@ -1,0 +1,3 @@
+class JsonAnyGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path("templates", __dir__)
+end

--- a/lib/generators/json_any/json_any_generator.rb
+++ b/lib/generators/json_any/json_any_generator.rb
@@ -1,3 +1,28 @@
-class JsonAnyGenerator < Rails::Generators::NamedBase
+class JsonanyGenerator < Rails::Generators::Base
   source_root File.expand_path("templates", __dir__)
+
+  argument :json_file, type: :string
+  attr_reader :json_config, :model_name, :model_name_plural, :model_name_underscore
+
+  def read_file
+    data = File.read(json_file)
+    @json_config = JSON.parse(data)
+    @model_name = @json_config["model_name"]
+    @model_name_underscore = @model_name.underscore
+    @model_name_plural = @model_name_underscore.pluralize
+    @command = @json_config['command']
+  end
+
+  def create_generator
+    querystr = ''
+    @json_config["columns"].each do |column|
+      querystr << "#{column["name"]}:#{column["type"]} "
+    end
+    generate "#{@command} #{@model_name} #{querystr}"
+    # Example output: generate "scaffold User email:string first_name:string last_name:string"
+
+    # Unused alternative method:
+    # hook_for :scaffold_controller, in: :rails, as: :controller
+  end
+
 end

--- a/orders_schema.json
+++ b/orders_schema.json
@@ -5,5 +5,6 @@
     {"name": "user", "type": "reference", "null": false, "display_field": "email"},
     {"name": "item", "type": "reference", "null": false, "display_field": "name"}
   ],
+  "command": "scaffold",
   "primary_field": "number"
 }

--- a/test/lib/generators/json_any_generator_test.rb
+++ b/test/lib/generators/json_any_generator_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+require "generators/json_any/json_any_generator"
+
+class JsonAnyGeneratorTest < Rails::Generators::TestCase
+  tests JsonAnyGenerator
+  destination Rails.root.join("tmp/generators")
+  setup :prepare_destination
+
+  # test "generator runs without errors" do
+  #   assert_nothing_raised do
+  #     run_generator ["arguments"]
+  #   end
+  # end
+end

--- a/users_schema.json
+++ b/users_schema.json
@@ -5,5 +5,7 @@
     {"name": "first_name", "type": "string"},
     {"name": "last_name", "type": "string"}
   ],
-  "primary_field": "email"
+  "primary_field": "email",
+  "command": "scaffold",
+  "//exampleoutput":  "scaffold User email:string first_name:string last_name:string"
 }


### PR DESCRIPTION
## Description
The idea being...

Use the json schema to run the normal generators.
If you want to do more stuff after that then have that in the generator.

Or make a new generator with this generator as the base generator.

## Potential problems:
Possibly you want to wait for the generate command to finish adding all the files before doing the new stuff on top. This change may or may not support that capability but feel free to play with that feature and report back.